### PR TITLE
Use new Roblox GameJoin API endpoint instead of removed AssetGame API endpoint (fix issue #8)

### DIFF
--- a/src/getServerInfo.ts
+++ b/src/getServerInfo.ts
@@ -1,9 +1,5 @@
 import phin from 'phin'
-import { IJoinTicket } from './types/JoinTicketTypes'
-
-interface IAssetGameResponse {
-	joinScriptUrl: string
-}
+import { IAssetGameResponse, IJoinScript } from './types/JoinTicketTypes'
 
 export async function _GetJoinTicket(placeId: number | string, jobId: string, cookie: string) {
 	if (!placeId) throw new Error('Expected a placeId')
@@ -30,6 +26,8 @@ export async function _GetJoinTicket(placeId: number | string, jobId: string, co
 
 	if (initialRequest.statusCode === 200 && initialRequest.body) {
 		const body = initialRequest.body
+		console.log(body)
+
 		if (!body.jobId || !body.joinScript) throw 'No joinScript or jobId'
 		
 		return body.joinScript
@@ -43,6 +41,6 @@ export async function _GetServerData(placeId: number | string, jobId: string, co
 	if (!jobId) throw new Error('Expected a jobId')
 	if (!cookie) throw new Error('Expected a cookie')
 
-	const gameData: IJoinTicket = await _GetJoinTicket(placeId, jobId, cookie)
+	const gameData: IJoinScript = await _GetJoinTicket(placeId, jobId, cookie)
 	return gameData
 }

--- a/src/getServerInfo.ts
+++ b/src/getServerInfo.ts
@@ -26,8 +26,6 @@ export async function _GetJoinTicket(placeId: number | string, jobId: string, co
 
 	if (initialRequest.statusCode === 200 && initialRequest.body) {
 		const body = initialRequest.body
-		console.log(body)
-
 		if (!body.jobId || !body.joinScript) throw 'No joinScript or jobId'
 		
 		return body.joinScript

--- a/src/types/JoinTicketTypes.d.ts
+++ b/src/types/JoinTicketTypes.d.ts
@@ -26,40 +26,56 @@ export interface IServerConnection {
 	Port: number
 }
 
-export interface IJoinTicket {
-	ClientPort: number
-	MachineAddress: string
-	ServerPort: number
-	ServerConnections: Array<IServerConnection>
-	PingUrl: string
-	PingInterval: number
-	UserName: string
-	DisplayName: string
-	SeleniumTestMode: boolean
-	UserId: number
-	RobloxLocale: string
-	GameLocale: string
-	SuperSafeChat: boolean
-	CharacterAppearance: string
-	ClientTicket: string
-	GameId: string
-	PlaceId: number
-	BaseUrl: string
-	ChatStyle: string
-	CreatorId: number
-	CreatorTypeEnum: string
-	MembershipType: string
-	AccountAge: number
-	CookieStoreFirstTimePlayKey: string
-	CookieStoreFiveMinutePlayKey: string
-	CookieStoreEnabled: boolean
-	IsUnknownOrUnder13: boolean
-	GameChatType: string
-	SessionId: ISessionId
-	AnalyticsSessionId: string
-	DataCenterId: number
-	UniverseId: number
-	FollowUserId: number
-	characterAppearanceId: number
-	CountryCode: string
+export interface IJoinScript {
+	ClientPort: number,
+	MachineAddress: string,
+	ServerPort: number,
+	ServerConnections: Array<IServerConnection>,
+	DirectServerReturn: boolean,
+	PingUrl: string,
+	PingInterval: number,
+	UserName: string,
+	DisplayName: string,
+	SeleniumTestMode: false,
+	UserId: number,
+	RobloxLocale: string,
+	GameLocale: string,
+	SuperSafeChat: boolean,
+	FlexibileChatEnabled: boolean,
+	CharacterAppearance: string,
+	ClientTicket: string,
+	GameId: string,
+	PlaceId: number,
+	BaseUrl: string,
+	ChatStyle: string,
+	CreatorId: number,
+	CreatorTypeEnum: string,
+	MembershipType: string,
+	AccountAge: number,
+	CookieStoreFirstTimePlayKey: string,
+	CookieStoreFiveMinutePlayKey: string,
+	CookieStoreEnabled: boolean,
+	IsUnknownOrUnder13: boolean,
+	GameChatType: string,
+	SessionId: string, //ISessionId, but a string...
+	AnalyticsSessionId: string,
+	DataCenterId: number,
+	UniverseId: number,
+	FollowUserId: number,
+	characterAppearanceId: number,
+	CountryCode: string,
+	RandomSeed1: string,
+	ClientPublicKeyData: string,
+	RccVersion: string,
+	ChannelName: string
+}
+
+export interface IAssetGameResponse {
+	jobId: string,
+	status: number,
+	joinScriptUrl: string,
+	authenticationUrl: string,
+	authenticationTicket: string,
+	message: string | null,
+	joinScript: IJoinScript
 }


### PR DESCRIPTION
Instead of using the obsolete AssetGame endpoint, we can use the new GameJoin endpoint that provides the `joinScript` for us, so we do not need to make two web calls, only one!
Here is the endpoint: [POST /v1/join-game-instance](https://gamejoin.roblox.com/docs#!/GameJoin/post_v1_join_game_instance)

I do not know Typescript, so please let me know of anything that should be changed.

It's similar to https://github.com/recanman/RobloxServerGrabber, something that I released earlier this year.